### PR TITLE
Urlencode indicator in the URL

### DIFF
--- a/OTXv2.py
+++ b/OTXv2.py
@@ -7,9 +7,9 @@ from requests.packages.urllib3.util import Retry
 from requests.adapters import HTTPAdapter
 
 try:
-    from urllib.parse import urlencode
+    from urllib.parse import urlencode, quote_plus
 except ImportError:
-    from urllib import urlencode
+    from urllib import urlencode, quote_plus
 
 import IndicatorTypes
 
@@ -249,7 +249,7 @@ class OTXv2(object):
         indicator_url = self.create_url(INDICATOR_DETAILS)
         indicator_url += "{indicator_type}/{indicator}/{section}".format(
             indicator_type=indicator_type.slug,
-            indicator=indicator,
+            indicator=quote_plus(indicator),
             section=section
         )
         return indicator_url


### PR DESCRIPTION
Server returns HTTP 400 when queried for details on URL-unsafe indicators, especially of type `IndicatorType.URL`. The encoding should be the responsibility of the API, because
1) the actual implementation of query is encapsulated in its methods, users don't even know it is sent in URL
2) for consistency, API should be able to handle the same format (URL-unsafe that is) of IoCs that it returns, without any need for processing by the user

I'm sorry I didn't write any test for it, can't make the test to work, tried substituting `X_OTX_DEV_SERVER=https://otx.alienvault.com/` to no avail.