### PR TITLE
Create UnexpectedHTTPError Exception

### DIFF
--- a/OTXv2.py
+++ b/OTXv2.py
@@ -81,6 +81,13 @@ class RetryError(Exception):
 
     def __str__(self):
         return repr(self.value)
+    
+class UnexpectedHTTPError(Exception):
+    def __init__(self, value=None):
+        self.value = value or "Unexpected HTTP error"
+
+    def __str__(self):
+        return repr(self.value)
 
 
 class OTXv2(object):
@@ -135,7 +142,7 @@ class OTXv2(object):
         elif response.status_code == 404:
             raise NotFound()
         elif str(response.status_code)[0] != "2":
-            raise Exception("Unexpected http code: %r, response=%r", response.status_code, _response_json())
+            raise UnexpectedHTTPError("Unexpected http code: %r, response=%r", response.status_code, _response_json())
 
         return response
 


### PR DESCRIPTION
Create an additional Exception class for handling all non-successful HTTP responses that are not covered by the previously created exception classes. Allows clients who face 500 series HTTP errors to better catch those exceptions instead of being forced to catch all exceptions in their try/except blocks